### PR TITLE
1.2.2.1-40; tiny changes

### DIFF
--- a/Assembly-CSharp/GithubVersionHelper.cs
+++ b/Assembly-CSharp/GithubVersionHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Security.Authentication;
 using UnityEngine;
 
 namespace Modding
@@ -11,7 +12,10 @@ namespace Modding
     public class GithubVersionHelper
     {
         private static readonly WebClient WebClient = new WebClient();
-        
+
+        public const SslProtocols _Tls12 = (SslProtocols)0x00000C00;
+        public const SecurityProtocolType Tls12 = (SecurityProtocolType)_Tls12;
+
         private static GithubRelease FromJson(string json) => JsonUtility.FromJson<GithubRelease>(json);
 
         private readonly string _repositoryName;
@@ -23,6 +27,7 @@ namespace Modding
         public GithubVersionHelper(string repositoryName)
         {
             _repositoryName = repositoryName;
+            ServicePointManager.SecurityProtocol = Tls12;
         }
 
         /// <summary>
@@ -34,6 +39,8 @@ namespace Modding
             //Wyza - Have to disable this.  Unity doesn't support TLS 1.2 and github removed TLS 1.0/1.1 support.  Grumble
 
             return "0.0";
+
+            /*
             try
             {
                 //This needs to be added on every call
@@ -51,6 +58,7 @@ namespace Modding
                 Logger.LogError("Failed to fetch url with error: \n" +ex);
             }
             return string.Empty;
+            */
         }
         // ReSharper disable All
 #pragma warning disable 0649

--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -143,7 +143,7 @@ namespace Modding
         /// </summary>
         public Mod()
         {
-            _globalSettingsFilename = Application.persistentDataPath + ModHooks.PathSeperator + GetType().Name + ".GlobalSettings.json";
+            _globalSettingsFilename = Application.persistentDataPath + ModHooks.PathSeperator + GetType().Name + ".GlobalSettings-" + Constants.GAME_VERSION + ".json";
             LoadGlobalSettings();
         }
 

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -132,7 +132,7 @@ namespace Modding
             ApplicationQuitHook += SaveGlobalSettings;
 
             //Wyza - Have to disable this.  Unity doesn't support TLS 1.2 and github removed TLS 1.0/1.1 support.  Grumble
-            /*
+            
             try
             {
                 GithubVersionHelper githubVersionHelper = new GithubVersionHelper("seresharp/HollowKnight.Modding");
@@ -150,7 +150,7 @@ namespace Modding
             {
                 Logger.LogError("[API] - Couldn't check for new version." + ex);
             }
-            */
+            
 
             IsInitialized = true;
         }

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -20,14 +20,14 @@ namespace Modding
     {
         internal static bool IsInitialized;
 
-        private const int _modVersion = 39;
+        private const int _modVersion = 40;
 
         /// <summary>
         /// Contains the seperator for path's, useful for handling Mac vs Windows vs Linux
         /// </summary>
         public static char PathSeperator = SystemInfo.operatingSystem.Contains("Windows") ? '\\' : '/';
 
-        private static readonly string SettingsPath = Application.persistentDataPath + PathSeperator + "ModdingApi.GlobalSettings.json";
+        private static string SettingsPath;
         private static ModHooks _instance;
 
         private ModHooksGlobalSettings _globalSettings;
@@ -98,6 +98,7 @@ namespace Modding
 
         private ModHooks()
         {
+            SettingsPath = Application.persistentDataPath + PathSeperator + "ModdingApi.GlobalSettings-" + Constants.GAME_VERSION + ".json";
             Logger.Log("[API] - Adding GitHub SSL Cert to Allow for Checking of Mod Versions");
 
             SetupServicePointAuthorizor();
@@ -131,9 +132,10 @@ namespace Modding
             ApplicationQuitHook += SaveGlobalSettings;
 
             //Wyza - Have to disable this.  Unity doesn't support TLS 1.2 and github removed TLS 1.0/1.1 support.  Grumble
+            /*
             try
             {
-                GithubVersionHelper githubVersionHelper = new GithubVersionHelper("seanpr96/HollowKnight.Modding");
+                GithubVersionHelper githubVersionHelper = new GithubVersionHelper("seresharp/HollowKnight.Modding");
 
                 string currentGithubVersion = githubVersionHelper.GetVersion();
                 string[] temp = currentGithubVersion.Split('-');
@@ -148,6 +150,7 @@ namespace Modding
             {
                 Logger.LogError("[API] - Couldn't check for new version." + ex);
             }
+            */
 
             IsInitialized = true;
         }
@@ -1788,12 +1791,13 @@ namespace Modding
 
         /// <summary>
         /// Called whenever game tries to show cursor
+        /// TODO
         /// </summary>
         internal void OnCursor()
         {
             //Logger.LogFine("[API] - OnCursor Invoked"); // Too Spammy
 
-            Cursor.lockState = CursorLockMode.None;
+            Cursor.lockState = CursorLockMode.Confined;
             if (_CursorHook != null)
             {
                 _CursorHook.Invoke();
@@ -1805,6 +1809,9 @@ namespace Modding
                 return;
             }
             Cursor.visible = false;
+
+
+            
         }
 
 

--- a/Assembly-CSharp/Patches/InputHandler.cs
+++ b/Assembly-CSharp/Patches/InputHandler.cs
@@ -23,6 +23,7 @@ namespace Modding.Patches
         [MonoModReplace]
         private void OnGUI()
         {
+            /*
             Cursor.lockState = CursorLockMode.None;
             if (isTitleScreenScene)
             {
@@ -40,6 +41,52 @@ namespace Modding.Patches
                 return;
             }
             Cursor.visible = true;
+            */
+
+
+            if (isTitleScreenScene)
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = true;
+                //Cursor.set_lockState(1);
+                //Cursor.set_visible(true);
+                return;
+
+
+            }
+            if (this.isMenuScene)
+            {
+                if (this.controllerPressed)
+                {
+                    Cursor.lockState = CursorLockMode.Locked;
+                    Cursor.visible = false;
+
+                    //Cursor.set_lockState(1);
+                    //Cursor.set_visible(false);
+                    return;
+                }
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+
+                //Cursor.set_lockState(0);
+                //Cursor.set_visible(true);
+                return;
+            }
+            if (!GameManager.instance.isPaused)
+            //if (!this.gm.isPaused)
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+                //Cursor.set_lockState(1);
+                //Cursor.set_visible(false);
+                return;
+            }
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+
+            //Cursor.set_lockState(0);
+            //Cursor.set_visible(true);
+
         }
     }
 }


### PR DESCRIPTION
-Changes so mods use settings with name format <mod-name>.GlobalSettings-<game_version>.json to let different patch settings co-exists
-Restores vanilla 1.2.2.1 cursor functionality (ridiculously messy, temp breaks cursor hooks, but they're unused anyway)
-Commented out api version check, seeing as it doesn't work anyway (will probably just delete later). The version check available for mods left in, as removing it bricks debug : )